### PR TITLE
Add RxPY schedule compatibility shim

### DIFF
--- a/orchestration/__init__.py
+++ b/orchestration/__init__.py
@@ -1,4 +1,63 @@
 # Orchestration package
 
+"""Project level helpers and compatibility fixes."""
 
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def _apply_rx_schedule_patch() -> None:
+    """Apply a backwards compatible patch for RxPY 1.x.
+
+    Dagster 1.9 expects the RxPY 3.x ``BaseObserver.schedule`` signature,
+    which accepts ``(scheduler, state, action)``. The project pins RxPY 1.6
+    for Python 3.11 compatibility and that version exposes a ``schedule``
+    method that only accepts ``(scheduler, state)``. When Dagster passes an
+    extra ``action`` argument, the interpreter raises ``TypeError``.  To avoid
+    touching the dependency graph we provide a small compatibility shim that
+    gracefully handles the extended call signature.
+    """
+
+    try:
+        from rx.core import observerbase as observer_module
+    except Exception:  # pragma: no cover - RxPY might not be installed yet.
+        return
+
+    original_schedule = getattr(observer_module.ObserverBase, "schedule", None)
+    if original_schedule is None:
+        return
+
+    # Only patch implementations that still use the two-argument signature.
+    try:
+        argcount = original_schedule.__code__.co_argcount
+    except AttributeError:  # pragma: no cover - built-in/extension functions.
+        argcount = None
+
+    if argcount is not None and argcount >= 4:
+        # Already compatible with the expected call signature.
+        return
+
+    def _patched_schedule(self: Any, *args: Any, **kwargs: Any) -> Any:
+        """Compatibility wrapper that tolerates the extra ``action`` argument."""
+
+        try:
+            return original_schedule(self, *args, **kwargs)
+        except TypeError as error:
+            if len(args) == 3 and not kwargs:
+                scheduler, state, action = args
+                schedule_fn: Callable[..., Any] | None = getattr(
+                    scheduler, "schedule", None
+                )
+                if callable(schedule_fn) and callable(action):
+                    try:
+                        return schedule_fn(action, state)
+                    except TypeError:
+                        return schedule_fn(action)
+            raise error
+
+    observer_module.ObserverBase.schedule = _patched_schedule
+
+
+_apply_rx_schedule_patch()
 


### PR DESCRIPTION
## Summary
- add a compatibility patch for `BaseObserver.schedule` so Dagster can call the RxPY 3-style signature
- delegate the extra action argument to the scheduler to avoid the TypeError raised while streaming logs

## Testing
- python - <<'PY'
import orchestration
print('patched')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d6384a8f988325a28ba0527dcde699